### PR TITLE
Remove obsolete query parameter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -242,7 +242,7 @@ class DataSource {
   };
 
   loadDataQuality = async () => {
-    const response = await connection.api.get(`/datasources/${this.name}/analyze?data_source_name=${this.name}`);
+    const response = await connection.api.get(`/datasources/${this.name}/analyze`);
     let data;
     try {
         data = response.data['data_analysis']['input_columns_metadata'];


### PR DESCRIPTION
The data_source query parameter is not needed because it is available from the path/