### PR TITLE
Fix typo in the rename endpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,7 +136,7 @@ class Predictor {
 
     const request = setQueryParams(
       mergeParams,
-      `/predictors/${params.oldName}/renmame?new_name=${params.newName}`
+      `/predictors/${params.oldName}/rename?new_name=${params.newName}`
     );
     const response = await connection.api.get(request);
 


### PR DESCRIPTION
This PR fixes typo in rename endpoint. Server endpoint https://github.com/mindsdb/mindsdb_server/blob/ef893412b05f20371b23da61931df01ba9c81e46/mindsdb_server/namespaces/predictor.py#L388